### PR TITLE
[FIX] Issue #137 Errors when running on Windows

### DIFF
--- a/jupyter_book/build.py
+++ b/jupyter_book/build.py
@@ -271,7 +271,7 @@ def build_book(path_book, path_toc_yaml=None, config_file=None,
         # Modify the generated Markdown to work with Jekyll
 
         # Clean markdown for Jekyll quirks (e.g. extra escape characters)
-        with open(path_new_file, 'r') as ff:
+        with open(path_new_file, 'r', encoding='utf8') as ff:
             lines = ff.readlines()
         lines = _clean_lines(lines, path_new_file,
                              path_book, PATH_IMAGES_FOLDER)


### PR DESCRIPTION
Adding the 'encoding' parameter to the open() function in the file handler allowed for proper building as expected in a Windows 10 environment.

I went through the code base and found a few other file handle operations that do not declare the encoding when reading.  While this is unlikely to be an issue when writing (especially since the output is formatted using the yaml library), this type of bug may be possible on the other read operations.